### PR TITLE
Changed shebang

### DIFF
--- a/fritz-api.sh
+++ b/fritz-api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env/bash
 RC_OK=0
 RC_WARN=1
 RC_CRIT=2


### PR DESCRIPTION
Changed shebang to `#! /usr/bin/env/bash` to increase compatibility with OSes that have `bash` in some other place, such as NixOS.